### PR TITLE
Update ig.json

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -15,7 +15,7 @@
   "dependencyList": [ 
     {
        "name" : "aubase",
-       "location" : "http://fhir.hl7.org.au/fhir/base2017Apr"
+       "location" : "http://fhir.hl7.org.au/fhir/2017Apr"
     }
   ], 
   "special-urls": [ "http://cap.org/protocols" ],


### PR DESCRIPTION
Change dependency from http://fhir.hl7.org.au/fhir/base2017Apr, which does not currently exist to http://fhir.hl7.org.au/fhir/2017Apr